### PR TITLE
Fix manipulating UTF-8 strings in QJsonObject

### DIFF
--- a/qttypes/src/lib.rs
+++ b/qttypes/src/lib.rs
@@ -1771,22 +1771,22 @@ impl QJsonObject {
     pub fn insert(&mut self, key: &str, value: QJsonValue) {
         let len = key.len();
         let ptr = key.as_ptr();
-        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*", value as "QJsonValue"] { self->insert(QLatin1String(ptr, len), std::move(value)); })
+        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*", value as "QJsonValue"] { self->insert(QString::fromUtf8(ptr, len), std::move(value)); })
     }
     pub fn value(&self, key: &str) -> QJsonValue {
         let len = key.len();
         let ptr = key.as_ptr();
-        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] -> QJsonValue as "QJsonValue" { return self->value(QLatin1String(ptr, len)); })
+        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] -> QJsonValue as "QJsonValue" { return self->value(QString::fromUtf8(ptr, len)); })
     }
     pub fn take(&mut self, key: &str) -> QJsonValue {
         let len = key.len();
         let ptr = key.as_ptr();
-        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] -> QJsonValue as "QJsonValue" { return self->take(QLatin1String(ptr, len)); })
+        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] -> QJsonValue as "QJsonValue" { return self->take(QString::fromUtf8(ptr, len)); })
     }
     pub fn remove(&mut self, key: &str) {
         let len = key.len();
         let ptr = key.as_ptr();
-        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] { return self->remove(QLatin1String(ptr, len)); })
+        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] { return self->remove(QString::fromUtf8(ptr, len)); })
     }
     pub fn len(&self) -> usize {
         cpp!(unsafe [self as "QJsonObject*"] -> usize as "size_t" { return self->size(); })
@@ -1797,7 +1797,7 @@ impl QJsonObject {
     pub fn contains(&self, key: &str) -> bool {
         let len = key.len();
         let ptr = key.as_ptr();
-        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] -> bool as "bool" { return self->contains(QLatin1String(ptr, len)); })
+        cpp!(unsafe [self as "QJsonObject*", len as "size_t", ptr as "char*"] -> bool as "bool" { return self->contains(QString::fromUtf8(ptr, len)); })
     }
     pub fn keys(&self) -> Vec<String> {
         let len = self.len();


### PR DESCRIPTION
_Note: This PR is a replica of [the upstream PR](https://github.com/woboq/qmetaobject-rs/pull/279)._

During developing Whisperfish, I noticed that pushing emojis into QJsonObject and reading them back didn't work correctly.

Code:
```rust
fn grouped_reactions(&self) -> QByteArray {
    let mut map = std::collections::HashMap::new();

    for (reaction, _) in &self.reaction_list.pinned().borrow().reactions {
        *map.entry(reaction.emoji.clone()).or_insert(0) += 1;
    }
    log::trace!("{:?}", map);
    let mut qmap: qmetaobject::QJsonObject = qmetaobject::QJsonObject::default();
    for (emoji, count) in map {
        qmap.insert(&emoji, QVariant::from(count).into());
    }
    log::trace!("{:?}", qmap.to_json());
    qmap.to_json()
}
```

Output before:

```text
[2023-02-18T19:25:19Z TRACE whisperfish::model::reactions] {"😨": 1}
[2023-02-18T19:25:19Z TRACE whisperfish::model::reactions] {"ð
```

Output after:

```text
[2023-02-18T20:40:38Z TRACE whisperfish::model::reactions] {"😨": 1}
[2023-02-18T20:40:38Z TRACE whisperfish::model::reactions] {"😨":1}
```

The cause was as I suspected: Usage of `QString::fromLatin1(const char *str, qsizetype size)`  doesn't handle UTF-8 encoding correctly, but using `QString::fromUtf8(const char8_t *str, qsizetype size)` is able to handle it.